### PR TITLE
Properly link libdl

### DIFF
--- a/overridehostname/Makefile
+++ b/overridehostname/Makefile
@@ -9,10 +9,10 @@ BINDIR := bin
 all: $(TARGET)
 
 $(TARGET): $(SOURCE)
-	$(CC) -fPIC -g -Wall -shared -Wl,-soname,$@ -ldl -o $(BINDIR)/$@ $<
+	$(CC) -fPIC -g -Wall -shared -Wl,-soname,$@ -Wl,--no-undefined -o $(BINDIR)/$@ $< -ldl
 
 install: $(TARGET)
 	cp $(BINDIR)/$(TARGET) /usr/local/lib/
 
 
-# compile: gcc -fPIC -g -Wall -shared -Wl,-soname,liboverridehostname.so.1 -ldl -o liboverridehostname.so.1 overridehostname.c
+# compile: gcc -fPIC -g -Wall -shared -Wl,-soname,liboverridehostname.so.1 -Wl,--no-undefined -o liboverridehostname.so.1 overridehostname.c -ldl


### PR DESCRIPTION
Currently the -ldl flag is before the object files that require it, so it is not actually being used to resolve those symbols.  Moving it to the end fixes this.

Tested on Ubuntu 20.04 - without this fix even the hostname command fails, with this fix, everything works as expected.